### PR TITLE
Update google apiclient to v2-RC5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "composer/installers": "*",
     "cakedc/migrations": "2.4.0",
     "ExpandOnline/google-api-php-client": "dev-master",
-    "google/apiclient": "v1.1.4",
+    "google/apiclient": "^2.0.0@RC",
     "facebook/php-ads-sdk": "2.5.*",
     "facebook/php-sdk-v4": "~5.0",
     "ExpandOnline/bitly-api-php": "dev-master",


### PR DESCRIPTION
Dit breekt mogelijk zaken rondom deze library. Changes zijn voornamelijk Auth en enhancements:https://github.com/google/google-api-php-client/blob/master/UPGRADING.md

Waarom deze PR? Omdat ik anders op 4 verschillende repositories branches moet aanmaken om de upgrade uit te voeren en vervolgens 4 verschillende `composer.json` naar deze branches laten verwijzen om vervolgens dit weer weg te halen bij de PR. Zolang composer op DEO niet wordt geupdate kan dit geen kwaad.