### PR TITLE
S88.00 Make sure not the default auth.ini is used.

### DIFF
--- a/Lib/AdWords/AdWordsAuthManager.php
+++ b/Lib/AdWords/AdWordsAuthManager.php
@@ -60,9 +60,11 @@ class AdWordsAuthManager extends UpdatedGoogleAuthManager {
 	 */
 	public function getAuthContainer($userId) {
 		$authContainer = parent::getAuthContainer($userId);
-		$oauthInfo = $authContainer->service->GetOAuth2Info();
-		$oauthInfo['access_token'] = $authContainer->client->getOAuth2Service()->getAccessToken();
-		$oauthInfo['refresh_token'] = $authContainer->client->getOAuth2Service()->getRefreshToken();
+		$oauthInfo = [
+			'access_token' => $authContainer->client->getOAuth2Service()->getAccessToken(),
+			'client_id' => $authContainer->client->getClientId(),
+			'client_secret' => $authContainer->client->getClientSecret(),
+		];
 		$authContainer->service->SetOAuth2Info($oauthInfo);
 		return $authContainer;
 	}


### PR DESCRIPTION
The AdWords library uses the auth.ini in the vendor directory by default. Make sure we use the secrets and tokens from the JSON file. Issue @ google for this difference between the libraries: https://github.com/googleads/googleads-php-lib/issues/185